### PR TITLE
update ABV to more accurate calculation

### DIFF
--- a/src/Beercalc/Beercalc.php
+++ b/src/Beercalc/Beercalc.php
@@ -10,7 +10,7 @@ class Beercalc{
   */
   public static function abv($og, $fg){
     if($og > $fg && is_numeric($og) && is_numeric($fg))
-      return ($og - $fg) * 131;
+      return (76.08 * ($og - $fg) / (1.775 - $og)) * ($fg / 0.794);
     else
       return null;
   }

--- a/tests/unit/BeercalcTest.php
+++ b/tests/unit/BeercalcTest.php
@@ -5,13 +5,13 @@ namespace Beercalc;
 class BeercalcTest extends \PHPUnit_Framework_TestCase {
 
   public function testABV(){
-    $this->assertEquals(7.204999999999992, Beercalc::abv(1.055, 1));
+    $this->assertEquals(7.319479429051208, Beercalc::abv(1.055, 1));
     $this->assertEquals(null, Beercalc::abv(1, 1.055));
     $this->assertEquals(null, Beercalc::abv("asdf", "asdf"));
   }
 
   public function testABW(){
-    $this->assertEquals(5.691949999999994, Beercalc::abw(1.055, 1));
+    $this->assertEquals(5.782388748950455, Beercalc::abw(1.055, 1));
     $this->assertEquals(null, Beercalc::abw(1, 1.055));
     $this->assertEquals(null, Beercalc::abw("asdf", "asdf"));
   }
@@ -75,7 +75,7 @@ class BeercalcTest extends \PHPUnit_Framework_TestCase {
   }
 
   public function testCalories(){
-    $this->assertEquals(227.57821703464833, Beercalc::calories(1.070, 1.015));  // Based on http://hbd.org/ensmingr/
+    $this->assertEquals(234.97692128247783, Beercalc::calories(1.070, 1.015));  // Based on http://hbd.org/ensmingr/
     $this->assertEquals(null, Beercalc::calories(1.015, 1.070));
     $this->assertEquals(null, Beercalc::calories(null, null));
     $this->assertEquals(null, Beercalc::calories("asdf", "asdf"));


### PR DESCRIPTION
Switched the ABV calculation to: ABV =(76.08 * (og-fg) / (1.775-og)) * (fg / 0.794)
This is supposed to be more accurate at higher gravities. Source: http://www.brewersfriend.com/2011/06/16/alcohol-by-volume-calculator-updated/